### PR TITLE
Temp Fix for Windows Console

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -7,7 +7,7 @@
 
     <groupId>EzASM</groupId>
     <artifactId>EzASM</artifactId>
-    <version>1.0.1</version>
+    <version>1.0.2</version>
     <description>An assembly-like programming language for use in education</description>
     <url>https://github.com/ezasm-org/EzASM/</url>
     <inceptionYear>2022</inceptionYear>

--- a/src/main/java/com/ezasm/gui/console/ConsoleTextArea.java
+++ b/src/main/java/com/ezasm/gui/console/ConsoleTextArea.java
@@ -3,7 +3,6 @@ package com.ezasm.gui.console;
 import com.ezasm.gui.util.IThemeable;
 import com.ezasm.gui.util.EditorTheme;
 import com.ezasm.gui.util.NullOutputStream;
-import com.ezasm.util.SystemStreams;
 
 import javax.swing.*;
 import javax.swing.text.*;

--- a/src/main/java/com/ezasm/gui/console/ConsoleTextArea.java
+++ b/src/main/java/com/ezasm/gui/console/ConsoleTextArea.java
@@ -3,6 +3,7 @@ package com.ezasm.gui.console;
 import com.ezasm.gui.util.IThemeable;
 import com.ezasm.gui.util.EditorTheme;
 import com.ezasm.gui.util.NullOutputStream;
+import com.ezasm.util.SystemStreams;
 
 import javax.swing.*;
 import javax.swing.text.*;
@@ -79,6 +80,11 @@ public class ConsoleTextArea extends JTextPane implements IThemeable {
      * @return Gets the string remaining after the fixed text.
      */
     private String getRemainingString() {
+        // Handle issue with instructions on Windows
+        // TODO use a better workaround that doesnt involve setting the text
+        if (getText().contains("\r")) {
+            setText(getText().replace("\r", ""));
+        }
         try {
             return getText(fixedTextEnd, getText().length() - fixedTextEnd + 1);
         } catch (BadLocationException ignored) {
@@ -135,6 +141,7 @@ public class ConsoleTextArea extends JTextPane implements IThemeable {
                 if (pos >= fixedTextEnd && e.getKeyCode() == '\n') {
                     // Legal newline character entered, save previously given text as final input
                     String toBuffer = getRemainingString();
+                    toBuffer = toBuffer.replace("\r", "");
                     console.writeTextToInputStream(toBuffer);
                     fixedTextEnd += toBuffer.length();
                 }


### PR DESCRIPTION
Temporary fix for issue with Windows GUI console where the CR character disrupts character counting.
This fix is inefficient but only effects Windows builds for the program. It also messes with console output text coloring. We will need to implement a proper fix once a route to such a fix is found.